### PR TITLE
Support serde.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: rust
 cache: cargo
-rust:
-    - nightly
+matrix:
+  include:
+    - rust: stable
+      env: FEATURES=""
+    - rust: stable
+      env: FEATURES="serde-1"
+script:
+  - cargo test --verbose --no-default-features --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ matrix:
     - rust: stable
       env: FEATURES=""
     - rust: stable
-      env: FEATURES="serde-1"
+      env: FEATURES="serde"
 script:
   - cargo test --verbose --no-default-features --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,9 @@ license = "MIT"
 name = "ordered-multimap"
 readme = "README.md"
 repository = "https://github.com/sgodwincs/ordered-multimap-rs"
-version = "0.4.0"
+version = "0.3.1"
 
 [dependencies]
 dlv-list = "0.2.2"
 hashbrown = "0.9.0"
 serde = { version = "1", optional = true }
-
-[features]
-serde-1 = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ license = "MIT"
 name = "ordered-multimap"
 readme = "README.md"
 repository = "https://github.com/sgodwincs/ordered-multimap-rs"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 dlv-list = "0.2.2"
 hashbrown = "0.9.0"
+serde = { version = "1", optional = true }
+
+[features]
+serde-1 = ["serde"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ anything definitive.
 
 # Features
 
- - `"serde-1"` for (de)serialization with `serde` version `1`.
+ - `serde` for (de)serialization.
 
 # TODO
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ keys and values.
 Preliminary benchmarks show that performance is quite decent but more will be required to state
 anything definitive.
 
+# Features
+
+ - `"serde-1"` for (de)serialization with `serde` version `1`.
+
 # TODO
 
 It is planned that a corresponding `SetOrderedMultimap` will also be included in this crate which

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
-# 0.4.0
+# 0.3.1
 
- - Added crate feature `"serde-1"` for (de)serialization with `serde` version `1`.
+ - Added crate feature `serde` for (de)serialization.
  - Implemented `IntoIterator` of owned key-value pairs for `ListOrderedMultimap`.
 
 # 0.3.0

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+# 0.4.0
+
+ - Added crate feature `"serde-1"` for (de)serialization with `serde` version `1`.
+ - Implemented `IntoIterator` of owned key-value pairs for `ListOrderedMultimap`.
+
 # 0.3.0
 
  - Updated `hashbrown` dependency to `0.9.0`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod list_ordered_multimap;
 
 pub use self::list_ordered_multimap::ListOrderedMultimap;
+
+#[cfg(feature = "serde-1")]
+mod serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,5 @@ pub mod list_ordered_multimap;
 
 pub use self::list_ordered_multimap::ListOrderedMultimap;
 
-#[cfg(feature = "serde-1")]
+#[cfg(feature = "serde")]
 mod serde;

--- a/src/list_ordered_multimap.rs
+++ b/src/list_ordered_multimap.rs
@@ -1,5 +1,6 @@
 use dlv_list::{
-    Drain as VecListDrain, Index, Iter as VecListIter, IterMut as VecListIterMut, VecList,
+    Drain as VecListDrain, Index, IntoIter as VecListIntoIter, Iter as VecListIter,
+    IterMut as VecListIterMut, VecList,
 };
 use hashbrown::hash_map::{RawEntryMut, RawOccupiedEntryMut};
 use hashbrown::HashMap;
@@ -1669,6 +1670,22 @@ where
     }
 }
 
+impl<Key, Value, State> IntoIterator for ListOrderedMultimap<Key, Value, State>
+where
+    Key: Eq + Hash + Clone,
+    State: BuildHasher,
+{
+    type IntoIter = IntoIter<Key, Value>;
+    type Item = (Key, Value);
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            keys: self.keys,
+            iter: self.values.into_iter(),
+        }
+    }
+}
+
 impl<Key, Value, State> PartialEq for ListOrderedMultimap<Key, Value, State>
 where
     Key: Eq + Hash,
@@ -3014,6 +3031,70 @@ impl<'map, Key, Value> Iterator for IterMut<'map, Key, Value> {
     }
 }
 
+/// An iterator that owns and yields all key-value pairs in a multimap. The order of
+/// the yielded items is always in the order that they were inserted.
+pub struct IntoIter<Key, Value> {
+    // The list of the keys in the map. This is ordered by time of insertion.
+    keys: VecList<Key>,
+
+    /// The iterator over the list of all values. This is ordered by time of insertion.
+    iter: VecListIntoIter<ValueEntry<Key, Value>>,
+}
+
+impl<Key, Value> IntoIter<Key, Value> {
+    /// Creates an iterator that yields immutable references to all key-value pairs in a multimap.
+    pub fn iter(&self) -> Iter<Key, Value> {
+        Iter {
+            keys: &self.keys,
+            iter: self.iter.iter(),
+        }
+    }
+}
+
+impl<Key, Value> Debug for IntoIter<Key, Value>
+where
+    Key: Debug,
+    Value: Debug,
+{
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str("IntoIter(")?;
+        formatter.debug_list().entries(self.iter()).finish()?;
+        formatter.write_str(")")
+    }
+}
+
+impl<Key, Value> DoubleEndedIterator for IntoIter<Key, Value>
+where
+    Key: Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let value_entry = self.iter.next_back()?;
+        let key = self.keys.get(value_entry.key_index).cloned().unwrap();
+        Some((key, value_entry.value))
+    }
+}
+
+impl<Key, Value> ExactSizeIterator for IntoIter<Key, Value> where Key: Clone {}
+
+impl<Key, Value> FusedIterator for IntoIter<Key, Value> where Key: Clone {}
+
+impl<Key, Value> Iterator for IntoIter<Key, Value>
+where
+    Key: Clone,
+{
+    type Item = (Key, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value_entry = self.iter.next()?;
+        let key = self.keys.get(value_entry.key_index).cloned().unwrap();
+        Some((key, value_entry.value))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
 /// An iterator that yields immutable references to all keys and their value iterators. The order of
 /// the yielded items is always in the order the keys were first inserted.
 pub struct KeyValues<'map, Key, Value, State = RandomState> {
@@ -3706,6 +3787,7 @@ mod test {
         check_bounds::<EntryValuesMut<'static, (), ()>>();
         check_bounds::<Iter<'static, (), ()>>();
         check_bounds::<IterMut<'static, (), ()>>();
+        check_bounds::<IntoIter<(), ()>>();
         check_bounds::<KeyValues<'static, (), ()>>();
         check_bounds::<KeyValuesDrain<'static, (), ()>>();
         check_bounds::<KeyValuesEntryDrain<'static, (), ()>>();
@@ -4085,6 +4167,27 @@ mod test {
     }
 
     #[test]
+    fn test_iter_size_hint() {
+        let mut map = ListOrderedMultimap::new();
+
+        map.insert("key1", "value1");
+        map.append("key2", "value2");
+        map.append("key2", "value3");
+        map.append("key1", "value4");
+
+        let mut iter = map.iter();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
     fn test_iter_mut_debug() {
         let mut map = ListOrderedMultimap::new();
 
@@ -4162,7 +4265,7 @@ mod test {
     }
 
     #[test]
-    fn test_iter_size_hint() {
+    fn test_into_iter_debug() {
         let mut map = ListOrderedMultimap::new();
 
         map.insert("key1", "value1");
@@ -4170,7 +4273,63 @@ mod test {
         map.append("key2", "value3");
         map.append("key1", "value4");
 
-        let mut iter = map.iter();
+        let iter = map.into_iter();
+        assert_eq!(
+            format!("{:?}", iter),
+            r#"IntoIter([("key1", "value1"), ("key2", "value2"), ("key2", "value3"), ("key1", "value4")])"#
+        );
+    }
+
+    #[test]
+    fn test_into_iter_double_ended() {
+        let mut map = ListOrderedMultimap::new();
+
+        map.insert("key1", "value1");
+        map.append("key2", "value2");
+        map.append("key2", "value3");
+        map.append("key1", "value4");
+
+        let mut iter = map.into_iter();
+        assert_eq!(iter.next(), Some(("key1", "value1")));
+        assert_eq!(iter.next_back(), Some(("key1", "value4")));
+        assert_eq!(iter.next(), Some(("key2", "value2")));
+        assert_eq!(iter.next_back(), Some(("key2", "value3")));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_into_iter_empty() {
+        let map: ListOrderedMultimap<&str, &str> = ListOrderedMultimap::new();
+        let mut iter = map.into_iter();
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_into_iter_fused() {
+        let mut map = ListOrderedMultimap::new();
+
+        map.insert("key", "value");
+
+        let mut iter = map.into_iter();
+        assert_eq!(iter.next(), Some(("key", "value")));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_into_iter_size_hint() {
+        let mut map = ListOrderedMultimap::new();
+
+        map.insert("key1", "value1");
+        map.append("key2", "value2");
+        map.append("key2", "value3");
+        map.append("key1", "value4");
+
+        let mut iter = map.into_iter();
         assert_eq!(iter.size_hint(), (4, Some(4)));
         iter.next();
         assert_eq!(iter.size_hint(), (3, Some(3)));

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -10,7 +10,7 @@ use crate::ListOrderedMultimap;
 
 impl<K, V, S> Serialize for ListOrderedMultimap<K, V, S>
 where
-    K: Serialize + Hash + Eq,
+    K: Eq + Hash + Serialize,
     V: Serialize,
     S: BuildHasher,
 {
@@ -32,7 +32,7 @@ impl<'de, K, V, S> Visitor<'de> for ListOrderedMultimapVisitor<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
-    S: Default + BuildHasher,
+    S: BuildHasher + Default,
 {
     type Value = ListOrderedMultimap<K, V, S>;
 
@@ -60,7 +60,7 @@ impl<'de, K, V, S> Deserialize<'de> for ListOrderedMultimap<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
-    S: Default + BuildHasher,
+    S: BuildHasher + Default,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -72,7 +72,7 @@ where
 
 impl<'de, K, V, S, E> IntoDeserializer<'de, E> for ListOrderedMultimap<K, V, S>
 where
-    K: IntoDeserializer<'de, E> + Eq + Hash + Clone,
+    K: Clone + Eq + Hash + IntoDeserializer<'de, E>,
     V: IntoDeserializer<'de, E>,
     S: BuildHasher,
     E: Error,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,85 @@
+use serde::de::value::MapDeserializer;
+use serde::de::{Deserialize, Deserializer, Error, IntoDeserializer, MapAccess, Visitor};
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+use core::fmt::{self, Formatter};
+use core::hash::{BuildHasher, Hash};
+use core::marker::PhantomData;
+
+use crate::ListOrderedMultimap;
+
+impl<K, V, S> Serialize for ListOrderedMultimap<K, V, S>
+where
+    K: Serialize + Hash + Eq,
+    V: Serialize,
+    S: BuildHasher,
+{
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        let mut map_serializer = serializer.serialize_map(Some(self.values_len()))?;
+        for (key, value) in self {
+            map_serializer.serialize_entry(key, value)?;
+        }
+        map_serializer.end()
+    }
+}
+
+struct ListOrderedMultimapVisitor<K, V, S>(PhantomData<(K, V, S)>);
+
+impl<'de, K, V, S> Visitor<'de> for ListOrderedMultimapVisitor<K, V, S>
+where
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
+    S: Default + BuildHasher,
+{
+    type Value = ListOrderedMultimap<K, V, S>;
+
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "a map")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut map = ListOrderedMultimap::with_capacity_and_hasher(
+            access.size_hint().unwrap_or_default(),
+            access.size_hint().unwrap_or_default(),
+            S::default(),
+        );
+        while let Some((key, value)) = access.next_entry()? {
+            map.append(key, value);
+        }
+        Ok(map)
+    }
+}
+
+impl<'de, K, V, S> Deserialize<'de> for ListOrderedMultimap<K, V, S>
+where
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
+    S: Default + BuildHasher,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ListOrderedMultimapVisitor(PhantomData))
+    }
+}
+
+impl<'de, K, V, S, E> IntoDeserializer<'de, E> for ListOrderedMultimap<K, V, S>
+where
+    K: IntoDeserializer<'de, E> + Eq + Hash + Clone,
+    V: IntoDeserializer<'de, E>,
+    S: BuildHasher,
+    E: Error,
+{
+    type Deserializer = MapDeserializer<'de, <Self as IntoIterator>::IntoIter, E>;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        MapDeserializer::new(self.into_iter())
+    }
+}


### PR DESCRIPTION
Implements #9.

---

I couldn't  treat arrays of tables `[[key]]` as `ListOrderedMultimap<Key, Table>` but I learned it would violate the TOML spec.