### PR TITLE
feat: Add no_std mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build & run tests
         run: cargo test --all-features
+      - name: Build without libstd
+        run: cargo build --no-default-features
+      - name: Build without libstd with serde
+        run: cargo build --no-default-features --features serde
   miri:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ readme = "README.md"
 categories = ["data-structures"]
 
 [dependencies]
-dlv-list = "0.4.0"
-hashbrown = "0.13.2"
-serde = { version = "1", optional = true }
+dlv-list = { version = "0.5", default-features = false }
+hashbrown = { version = "0.13.2", default-features = false }
+serde = { version = "1", optional = true, default-features = false }
+
+[features]
+default = ["std"]
+std = ["dlv-list/std"]
 
 [dev-dependencies]
 coverage-helper = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Basic benchmarks show that the performance of this crate is on par with that of 
 
 ## Features
 
+ - `std` (default) enables usage of the standard library. Disabling this features allows this crate to be used in `no_std` environments.
  - `serde` for (de)serialization.
 
 ## TODO

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //! See the type documentation for more information.
 
 #![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod list_ordered_multimap;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -78,7 +78,7 @@ where
 }
 
 #[allow(unused_results)]
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
   use coverage_helper::test;
   use serde_test::{assert_de_tokens_error, assert_tokens, Token};


### PR DESCRIPTION
This PR adds an `std` feature that, when disabled, allows this crate to be used on `no_std`. This is a breaking change.

This is a draft PR until sgodwincs/dlv-list-rs#13 is merged.