### PR TITLE
Bump hashbrown to 0.15.2 and remove deprecated coverage_helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+ - Updated `hashbrown` dependency to `0.15.2`.
+ - Removed `coverage-helper` dependency
+ - Addressed clippy warnings regarding `#[coverage(...)]` attribute
+
 # 0.7.1 - 10-24-2023
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.71.1"
 
 [dependencies]
 dlv-list = { version = "0.5", default-features = false }
-hashbrown = { version = "0.14.0", default-features = false }
+hashbrown = { version = "0.15.2", default-features = false, features=["raw-entry"] }
 serde = { version = "1", optional = true, default-features = false }
 
 [features]
@@ -20,5 +20,7 @@ default = ["std"]
 std = ["dlv-list/std"]
 
 [dev-dependencies]
-coverage-helper = "0.2.0"
 serde_test = "1.0.144"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/src/list_ordered_multimap.rs
+++ b/src/list_ordered_multimap.rs
@@ -3524,8 +3524,8 @@ where
 
 #[allow(unused_results)]
 #[cfg(all(test, feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
-  use coverage_helper::test;
 
   use super::*;
 
@@ -5361,7 +5361,7 @@ mod test {
   #[test]
   fn test_dummy_hasher_finish() {
     let hasher = DummyHasher;
-    hasher.finish();
+    let _ = hasher.finish();
   }
 
   #[should_panic]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -79,8 +79,9 @@ where
 
 #[allow(unused_results)]
 #[cfg(all(test, feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
-  use coverage_helper::test;
+
   use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
   use super::*;


### PR DESCRIPTION
This PR bumps the `hashbrown` dep to latest (0.15.2), addresses the deprecated use of `coverage_helper::tests`, and adds a lint table to remove the warning emitted for the `coverage_nightly` attribute. The dev dependency on `coverage_helper` is removed in favor of the [now-recommended](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#exclude-code-from-coverage) form:
```
#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
...
#[cfg(test)]
#[cfg_attr(coverage_nightly, coverage(off))]
mod test {
...
}
```